### PR TITLE
Explicitly specify Python2 as the interpreter

### DIFF
--- a/vgrep
+++ b/vgrep
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """This module is a reimpementation of the ancient cgvg perl scripts.
 Visit https://github.com/vrothberg/vgrep for more information."""


### PR DESCRIPTION
On some distributions /usr/bin/python defaults to Python 3. Instead explicitly ask for a valid Python 2 interpreter on the system