### PR TITLE
vgrep: if ~/.cache/ is not present, create it

### DIFF
--- a/vgrep
+++ b/vgrep
@@ -239,6 +239,8 @@ def grep(symbol, nogit=False, word=False):
 
 def dump(data):
     """Dump %data to the local cache."""
+    if not os.path.exists(os.path.dirname(CACHE)):
+        os.makedirs(os.path.dirname(CACHE))
     pickle.dump(data, open(CACHE, "wb"))
 
 


### PR DESCRIPTION
Some systems don't have ~/.cache/ so create it before attempting to
write out a file to it.

Problem pointed out by @GeertJohan