### PR TITLE
grep: do recursive grep into git-submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ An example call could look as follows:
 
 - **'--no-git'** to use to *grep* instead (required outside a Git repository).
 
+- **'--no-git-submodules'** to not recurse into Git submodules. Git submodule
+  search is only useful within a Git Repository (see --no-git).
+
 - **'--no-header'** to compress the whitespace a bit to help fit more
   information on each line.  This option is helpful if you are working on a
   terminal with few columns, or have long filenames or paths to search.

--- a/vgrep
+++ b/vgrep
@@ -246,16 +246,29 @@ def grep(grep_args, nogit, nogitsubmodules):
     git_grep_results = execute(git_grep_cmd).rsplit("\n")
 
     # grep in submodules
-    if nogitsubmodules:
-        git_grep_submodule_results = []
-    else:
-        sed_cmd = 'sed "s#^#$path/#"'
-        git_grep_submodule_cmd = "git submodule --quiet foreach --recursive {cmd}".format(
-            cmd=quote(git_grep_cmd + " | " + sed_cmd)
+    if nogitsubmodules is False:
+        cwd = os.path.abspath(os.path.curdir)
+        # Get all submodules (recursive)
+        git_submodule_cmd = "git submodule --quiet foreach --recursive {cmd}".format(
+            cmd=quote('echo "$toplevel/$path"'),
         )
-        git_grep_submodule_results = execute(git_grep_submodule_cmd).rsplit("\n")
+        submodules = execute(git_submodule_cmd).rsplit("\n")
+        for submodule in filter(None, submodules):
+            # check if submodule is below the current working directory
+            submodule = os.path.normpath(submodule)
+            if os.path.commonprefix([submodule, cwd]) != cwd:
+                continue
+            # Get the path relative to the CWD
+            submodule = os.path.relpath(submodule, cwd)
 
-    return git_grep_results + git_grep_submodule_results
+            # Start grep within the submodule
+            git_submodule_grep_cmd = "cd {pwd} && {grep}".format(pwd=quote(submodule), grep=git_grep_cmd)
+            lines = execute(git_submodule_grep_cmd).rsplit("\n")
+            # Prepend the relative submodule path to each line
+            for line in filter(None, lines):
+                git_grep_results.append(os.path.join(submodule, line))
+
+    return git_grep_results
 
 def dump(data):
     """

--- a/vgrep
+++ b/vgrep
@@ -18,6 +18,7 @@ import sys
 import pickle
 from subprocess import Popen, PIPE, STDOUT
 from array import array
+from pipes import quote
 
 HOMEDIR = os.getenv("HOME")
 CACHE = HOMEDIR + "/.cache/vgrep"
@@ -37,6 +38,9 @@ def parse_options():
     parser.add_argument('--no-git', dest='nogit', action='store_true',
                         default=False,
                         help="use 'grep' instead of 'git grep'")
+    parser.add_argument('--no-git-submodules', dest='nogitsubmodules', action='store_true',
+                        default=False,
+                        help="do not search in git submodules")
     parser.add_argument('--no-less', dest='noless', action='store_true',
                         default=False,
                         help="print to stdout instead of using less")
@@ -81,7 +85,7 @@ def main():
         gitargs = ["'%s'" % x for x in gitargs]  # needed to pass args to grep
         grep_args = " ".join(gitargs)
 
-        slocs = grep(grep_args, args.nogit)
+        slocs = grep(grep_args, args.nogit, args.nogitsubmodules)
         slocs = filter(None, slocs)  # filter empty hits
         if not slocs:
             # dump and exit if there is not hit
@@ -224,7 +228,7 @@ def execute(cmd):
     return stdout
 
 
-def grep(grep_args, nogit):
+def grep(grep_args, nogit, nogitsubmodules):
     """
     Search symbol in current Git tree and return the output. If %nogit is set
     grep is called instead of git grep.
@@ -238,8 +242,20 @@ def grep(grep_args, nogit):
         return execute("%s grep %s ." % (colors, grep_args)).rsplit("\n")
 
     colors = "-c 'color.grep.match=red bold'"
-    return execute("HOME= git %s  grep %s" % (colors, grep_args)).rsplit("\n")
+    git_grep_cmd = "HOME= git {colors} grep {args}".format(colors=colors, args=grep_args)
+    git_grep_results = execute(git_grep_cmd).rsplit("\n")
 
+    # grep in submodules
+    if nogitsubmodules:
+        git_grep_submodule_results = []
+    else:
+        sed_cmd = 'sed "s#^#$path/#"'
+        git_grep_submodule_cmd = "git submodule --quiet foreach --recursive {cmd}".format(
+            cmd=quote(git_grep_cmd + " | " + sed_cmd)
+        )
+        git_grep_submodule_results = execute(git_grep_submodule_cmd).rsplit("\n")
+
+    return git_grep_results + git_grep_submodule_results
 
 def dump(data):
     """

--- a/vgrep
+++ b/vgrep
@@ -242,31 +242,32 @@ def grep(grep_args, nogit, nogitsubmodules):
         return execute("%s grep %s ." % (colors, grep_args)).rsplit("\n")
 
     colors = "-c 'color.grep.match=red bold'"
-    git_grep_cmd = "HOME= git {colors} grep {args}".format(colors=colors, args=grep_args)
+    git_grep_cmd = "HOME= git %s grep %s" %(colors, grep_args)
     git_grep_results = execute(git_grep_cmd).rsplit("\n")
 
-    # grep in submodules
-    if nogitsubmodules is False:
-        cwd = os.path.abspath(os.path.curdir)
-        # Get all submodules (recursive)
-        git_submodule_cmd = "git submodule --quiet foreach --recursive {cmd}".format(
-            cmd=quote('echo "$toplevel/$path"'),
-        )
-        submodules = execute(git_submodule_cmd).rsplit("\n")
-        for submodule in filter(None, submodules):
-            # check if submodule is below the current working directory
-            submodule = os.path.normpath(submodule)
-            if os.path.commonprefix([submodule, cwd]) != cwd:
-                continue
-            # Get the path relative to the CWD
-            submodule = os.path.relpath(submodule, cwd)
+    # When submodules are ignored, we can return here.
+    if nogitsubmodules is True:
+        return git_grep_results
 
-            # Start grep within the submodule
-            git_submodule_grep_cmd = "cd {pwd} && {grep}".format(pwd=quote(submodule), grep=git_grep_cmd)
-            lines = execute(git_submodule_grep_cmd).rsplit("\n")
-            # Prepend the relative submodule path to each line
-            for line in filter(None, lines):
-                git_grep_results.append(os.path.join(submodule, line))
+    cwd = os.path.abspath(os.path.curdir)
+    # Get all submodules (recursive)
+    list_cmd = "git submodule --quiet foreach --recursive %s" %\
+                        quote('echo "$toplevel/$path"')
+    submodules = execute(list_cmd).rsplit("\n")
+    for submodule in filter(None, submodules):
+        # check if submodule is below the current working directory
+        submodule = os.path.normpath(submodule)
+        if os.path.commonprefix([submodule, cwd]) != cwd:
+            continue
+        # Get the path relative to the CWD
+        submodule = os.path.relpath(submodule, cwd)
+
+        # Start grep within the submodule
+        sub_grep_cmd = "cd %s && %s" % (quote(submodule), git_grep_cmd)
+        lines = execute(sub_grep_cmd).rsplit("\n")
+        # Prepend the relative submodule path to each line
+        for line in filter(None, lines):
+            git_grep_results.append(os.path.join(submodule, line))
 
     return git_grep_results
 


### PR DESCRIPTION
By default, git submodules are also considered, when git-grep is
used. With --no-git-submodules the old behavior (ignoring
git-submodules) is restored.