### PR TITLE
vgrep: add '?' support to -s

### DIFF
--- a/vgrep
+++ b/vgrep
@@ -160,8 +160,11 @@ def main():
                 show_expr = ask_show_expr(show_help)
             except EOFError:
                 break
-            show_help = False
-            dispatch_show_expr(show_expr, slocs, args)
+            if show_expr != "?":
+                show_help = False
+                dispatch_show_expr(show_expr, slocs, args)
+            else:
+                show_help = True;
     elif args.show:
         ret = dispatch_show_expr(args.show, slocs, args)
 


### PR DESCRIPTION
Sometimes you just want to see the help command again, and if you have
already typed a command, you can no longer do that.  So add support for
'?' to be a valid option to show the help again.
