### PR TITLE
logging: use string instead of *os.File

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -522,7 +522,7 @@ func getContextLines(index int, numLines int) [][]string {
 
 	file, err := os.Open(path)
 	if err != nil {
-		Log.Warnf("Error opening file '%s': %v", file, err)
+		Log.Warnf("Error opening file '%s': %v", path, err)
 		return nil
 	}
 	defer file.Close()


### PR DESCRIPTION
Fix a go-vet error by using the corresponding string instead of
*os.File when printing an os.Open() error.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>