### PR TITLE
don't error out if cache file doesn't exist

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -70,7 +70,10 @@ func main() {
 	if len(args) == 0 {
 		err = loadCache()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "No cache: %v\n", err)
+			if os.IsNotExist(err) {
+				os.Exit(0)
+			}
+			fmt.Fprintf(os.Stderr, "Error loading cache: %v\n", err)
 			os.Exit(1)
 		}
 	} else {


### PR DESCRIPTION
Don't error out if the cache file doesn't exist, which happens when
a user runs vgrep for the first time.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>