### PR TITLE
Fixes to command parsing, cache writing and comments 

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,4 +1,5 @@
 github.com/jessevdk/go-flags v1.4.0
+github.com/nightlyone/lockfile 0ad87eef1443f64d3d8c50da647e2b1552851124
 github.com/sirupsen/logrus v1.3.0
 golang.org/x/crypto ff983b9c42bc9fbf91556e191cc8efb585c16908 https://github.com/golang/crypto
 golang.org/x/sys 11f53e03133963fb11ae0588e08b5e0b85be8be5 https://github.com/golang/sys

--- a/vendor/github.com/nightlyone/lockfile/LICENSE
+++ b/vendor/github.com/nightlyone/lockfile/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012 Ingo Oeser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/nightlyone/lockfile/README.md
+++ b/vendor/github.com/nightlyone/lockfile/README.md
@@ -1,0 +1,52 @@
+lockfile
+=========
+Handle locking via pid files.
+
+[![Build Status Unix][1]][2]
+[![Build status Windows][3]][4]
+
+[1]: https://secure.travis-ci.org/nightlyone/lockfile.png
+[2]: https://travis-ci.org/nightlyone/lockfile
+[3]: https://ci.appveyor.com/api/projects/status/7mojkmauj81uvp8u/branch/master?svg=true
+[4]: https://ci.appveyor.com/project/nightlyone/lockfile/branch/master
+
+
+
+install
+-------
+Install [Go 1][5], either [from source][6] or [with a prepackaged binary][7].
+For Windows suport, Go 1.4 or newer is required.
+
+Then run
+
+	go get github.com/nightlyone/lockfile
+
+[5]: http://golang.org
+[6]: http://golang.org/doc/install/source
+[7]: http://golang.org/doc/install
+
+LICENSE
+-------
+MIT
+
+documentation
+-------------
+[package documentation at godoc.org](http://godoc.org/github.com/nightlyone/lockfile)
+
+install
+-------------------
+	go get github.com/nightlyone/lockfile
+
+
+contributing
+============
+
+Contributions are welcome. Please open an issue or send me a pull request for a dedicated branch.
+Make sure the git commit hooks show it works.
+
+git commit hooks
+-----------------------
+enable commit hooks via
+
+        cd .git ; rm -rf hooks; ln -s ../git-hooks hooks ; cd ..
+

--- a/vendor/github.com/nightlyone/lockfile/lockfile.go
+++ b/vendor/github.com/nightlyone/lockfile/lockfile.go
@@ -1,0 +1,211 @@
+// Package lockfile handles pid file based locking.
+// While a sync.Mutex helps against concurrency issues within a single process,
+// this package is designed to help against concurrency issues between cooperating processes
+// or serializing multiple invocations of the same process. You can also combine sync.Mutex
+// with Lockfile in order to serialize an action between different goroutines in a single program
+// and also multiple invocations of this program.
+package lockfile
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// Lockfile is a pid file which can be locked
+type Lockfile string
+
+// TemporaryError is a type of error where a retry after a random amount of sleep should help to mitigate it.
+type TemporaryError string
+
+func (t TemporaryError) Error() string { return string(t) }
+
+// Temporary returns always true.
+// It exists, so you can detect it via
+//	if te, ok := err.(interface{ Temporary() bool }); ok {
+//		fmt.Println("I am a temporay error situation, so wait and retry")
+//	}
+func (t TemporaryError) Temporary() bool { return true }
+
+// Various errors returned by this package
+var (
+	ErrBusy          = TemporaryError("Locked by other process")             // If you get this, retry after a short sleep might help
+	ErrNotExist      = TemporaryError("Lockfile created, but doesn't exist") // If you get this, retry after a short sleep might help
+	ErrNeedAbsPath   = errors.New("Lockfiles must be given as absolute path names")
+	ErrInvalidPid    = errors.New("Lockfile contains invalid pid for system")
+	ErrDeadOwner     = errors.New("Lockfile contains pid of process not existent on this system anymore")
+	ErrRogueDeletion = errors.New("Lockfile owned by me has been removed unexpectedly")
+)
+
+// New describes a new filename located at the given absolute path.
+func New(path string) (Lockfile, error) {
+	if !filepath.IsAbs(path) {
+		return Lockfile(""), ErrNeedAbsPath
+	}
+	return Lockfile(path), nil
+}
+
+// GetOwner returns who owns the lockfile.
+func (l Lockfile) GetOwner() (*os.Process, error) {
+	name := string(l)
+
+	// Ok, see, if we have a stale lockfile here
+	content, err := ioutil.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+
+	// try hard for pids. If no pid, the lockfile is junk anyway and we delete it.
+	pid, err := scanPidLine(content)
+	if err != nil {
+		return nil, err
+	}
+	running, err := isRunning(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	if running {
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return nil, err
+		}
+		return proc, nil
+	}
+	return nil, ErrDeadOwner
+
+}
+
+// TryLock tries to own the lock.
+// It Returns nil, if successful and and error describing the reason, it didn't work out.
+// Please note, that existing lockfiles containing pids of dead processes
+// and lockfiles containing no pid at all are simply deleted.
+func (l Lockfile) TryLock() error {
+	name := string(l)
+
+	// This has been checked by New already. If we trigger here,
+	// the caller didn't use New and re-implemented it's functionality badly.
+	// So panic, that he might find this easily during testing.
+	if !filepath.IsAbs(name) {
+		panic(ErrNeedAbsPath)
+	}
+
+	tmplock, err := ioutil.TempFile(filepath.Dir(name), filepath.Base(name)+".")
+	if err != nil {
+		return err
+	}
+
+	cleanup := func() {
+		_ = tmplock.Close()
+		_ = os.Remove(tmplock.Name())
+	}
+	defer cleanup()
+
+	if err := writePidLine(tmplock, os.Getpid()); err != nil {
+		return err
+	}
+
+	// EEXIST and similiar error codes, caught by os.IsExist, are intentionally ignored,
+	// as it means that someone was faster creating this link
+	// and ignoring this kind of error is part of the algorithm.
+	// The we will probably fail the pid owner check later, if this process is still alive.
+	// We cannot ignore ALL errors, since failure to support hard links, disk full
+	// as well as many other errors can happen to a filesystem operation
+	// and we really want to abort on those.
+	if err := os.Link(tmplock.Name(), name); err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+
+	fiTmp, err := os.Lstat(tmplock.Name())
+	if err != nil {
+		return err
+	}
+	fiLock, err := os.Lstat(name)
+	if err != nil {
+		// tell user that a retry would be a good idea
+		if os.IsNotExist(err) {
+			return ErrNotExist
+		}
+		return err
+	}
+
+	// Success
+	if os.SameFile(fiTmp, fiLock) {
+		return nil
+	}
+
+	proc, err := l.GetOwner()
+	switch err {
+	default:
+		// Other errors -> defensively fail and let caller handle this
+		return err
+	case nil:
+		if proc.Pid != os.Getpid() {
+			return ErrBusy
+		}
+	case ErrDeadOwner, ErrInvalidPid:
+		// cases we can fix below
+	}
+
+	// clean stale/invalid lockfile
+	err = os.Remove(name)
+	if err != nil {
+		// If it doesn't exist, then it doesn't matter who removed it.
+		if !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	// now that the stale lockfile is gone, let's recurse
+	return l.TryLock()
+}
+
+// Unlock a lock again, if we owned it. Returns any error that happend during release of lock.
+func (l Lockfile) Unlock() error {
+	proc, err := l.GetOwner()
+	switch err {
+	case ErrInvalidPid, ErrDeadOwner:
+		return ErrRogueDeletion
+	case nil:
+		if proc.Pid == os.Getpid() {
+			// we really own it, so let's remove it.
+			return os.Remove(string(l))
+		}
+		// Not owned by me, so don't delete it.
+		return ErrRogueDeletion
+	default:
+		// This is an application error or system error.
+		// So give a better error for logging here.
+		if os.IsNotExist(err) {
+			return ErrRogueDeletion
+		}
+		// Other errors -> defensively fail and let caller handle this
+		return err
+	}
+}
+
+func writePidLine(w io.Writer, pid int) error {
+	_, err := io.WriteString(w, fmt.Sprintf("%d\n", pid))
+	return err
+}
+
+func scanPidLine(content []byte) (int, error) {
+	if len(content) == 0 {
+		return 0, ErrInvalidPid
+	}
+
+	var pid int
+	if _, err := fmt.Sscanln(string(content), &pid); err != nil {
+		return 0, ErrInvalidPid
+	}
+
+	if pid <= 0 {
+		return 0, ErrInvalidPid
+	}
+	return pid, nil
+}

--- a/vendor/github.com/nightlyone/lockfile/lockfile_unix.go
+++ b/vendor/github.com/nightlyone/lockfile/lockfile_unix.go
@@ -1,0 +1,20 @@
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris aix
+
+package lockfile
+
+import (
+	"os"
+	"syscall"
+)
+
+func isRunning(pid int) (bool, error) {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false, err
+	}
+
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		return false, nil
+	}
+	return true, nil
+}

--- a/vendor/github.com/nightlyone/lockfile/lockfile_windows.go
+++ b/vendor/github.com/nightlyone/lockfile/lockfile_windows.go
@@ -1,0 +1,30 @@
+package lockfile
+
+import (
+	"syscall"
+)
+
+//For some reason these consts don't exist in syscall.
+const (
+	error_invalid_parameter = 87
+	code_still_active       = 259
+)
+
+func isRunning(pid int) (bool, error) {
+	procHnd, err := syscall.OpenProcess(syscall.PROCESS_QUERY_INFORMATION, true, uint32(pid))
+	if err != nil {
+		if scerr, ok := err.(syscall.Errno); ok {
+			if uintptr(scerr) == error_invalid_parameter {
+				return false, nil
+			}
+		}
+	}
+
+	var code uint32
+	err = syscall.GetExitCodeProcess(procHnd, &code)
+	if err != nil {
+		return false, err
+	}
+
+	return code == code_still_active, nil
+}

--- a/vgrep.go
+++ b/vgrep.go
@@ -51,7 +51,7 @@ func main() {
 	var err error
 	var waiter sync.WaitGroup
 
-	// Unkown flags will be ignored and stored in args to further pass them
+	// Unknown flags will be ignored and stored in args to further pass them
 	// to (git) grep.
 	parser := flags.NewParser(&Options, flags.Default|flags.IgnoreUnknown)
 	args, err := parser.ParseArgs(os.Args[1:])
@@ -71,7 +71,7 @@ func main() {
 
 	Log.Debugf("passed args: %s", args)
 
-	// Load the cache if there's no new querry, otherwise execute a new one.
+	// Load the cache if there's no new query, otherwise execute a new one.
 	err = makeLockFile()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating lock file: %v\n", err)
@@ -98,7 +98,7 @@ func main() {
 	}
 
 	// Execute the specified command and/or jump directly into the
-	// interactive sheel.
+	// interactive shell.
 	if Options.Show != "" || Options.Interactive {
 		commandParse(Options.Show)
 		waiter.Wait()
@@ -342,7 +342,7 @@ func cacheWriterHelper() error {
 	return file.Close()
 }
 
-// loadsCache loads the user-specific vgrep cache.
+// loadCache loads the user-specific vgrep cache.
 func loadCache() error {
 	Log.Debug("loadCache(): start")
 	defer Log.Debug("loadCache(): end")
@@ -394,8 +394,8 @@ func sortKeys(m map[string]int) []string {
 }
 
 // commandParse starts and dispatches user-specific vgrep commands.  If input
-// matches a vgrep selector commanShow will be executed.  It will promt the
-// user for commands we're running in interactive mode.
+// matches a vgrep selector commandShow will be executed. It will prompt the
+// user for commands if we're running in interactive mode.
 func commandParse(input string) {
 	Log.Debugf("commandParse(input=%s)", input)
 

--- a/vgrep.go
+++ b/vgrep.go
@@ -518,11 +518,12 @@ func dispatchCommand(input string) bool {
 	if command == "s" || command == "show" {
 		if len(indices) == 0 {
 			fmt.Println("Show requires specified selectors")
-			return false
+		} else {
+			for _, idx := range indices {
+				commandShow(idx)
+			}
 		}
-		for _, idx := range indices {
-			commandShow(idx)
-		}
+		return false
 	}
 
 	if command == "t" || command == "tree" {


### PR DESCRIPTION
These commits fix a few different things:

- Spelling mistakes in comments
- When running the `show` command, vgrep would show an "Unsupported command: "s"" warning after closing the editor.
- Sometimes the JSON cache file would be corrupt as the code does not properly wait for the `cacheWrite` goroutine to finish.