### PR TITLE
Makefile: use go proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export GOPROXY=https://proxy.golang.org
+
 SHELL= /bin/bash
 GO ?= go
 BUILD_DIR := ./build


### PR DESCRIPTION
Use GOPROXY=https://proxy.golang.org to speed up fetching dependencies.
Setting it makes `make vendor` six times faster in my local env.

For details please refer to https://proxy.golang.org/.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>