### PR TITLE
support vscode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,5 @@ require (
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
+
+go 1.13

--- a/vgrep.go
+++ b/vgrep.go
@@ -169,6 +169,11 @@ func (v *vgrep) insideGitTree() bool {
 	return inside
 }
 
+// isVscode checks if the terminal is running inside of vscode.
+func isVscode() bool {
+	return os.Getenv("TERM_PROGRAM") == "vscode"
+}
+
 // grep (git) greps with the specified args and stores the results in v.matches.
 func (v *vgrep) grep(args []string) {
 	var cmd []string
@@ -571,8 +576,17 @@ func (v *vgrep) commandPrintMatches(indices []int) bool {
 		toPrint = append(toPrint, []string{"Index", "File", "Line", "Content"})
 	}
 
+	isVscode := isVscode()
 	for _, i := range indices {
-		toPrint = append(toPrint, v.matches[i])
+		if isVscode {
+			// If we're running inside a vscode terminal, append the line to the
+			// file path, so we can quick jump to the specific location.  Note
+			// that dancing around with the indexes below is intentional - ugly
+			// but fast.
+			toPrint = append(toPrint, []string{v.matches[i][0], v.matches[i][1] + ":" + v.matches[i][2], v.matches[i][2], v.matches[i][3]})
+		} else {
+			toPrint = append(toPrint, v.matches[i])
+		}
 	}
 
 	cw := colwriter.New(4)

--- a/vgrep.go
+++ b/vgrep.go
@@ -1,6 +1,6 @@
 package main
 
-// (c) 2015-2019 Valentin Rothberg <valentinrothberg@gmail.com>
+// (c) 2015-2019 Valentin Rothberg <valentin@rothberg.email>
 //
 // Licensed under the terms of the GNU GPL License version 3.
 


### PR DESCRIPTION
When running inside a vscode terminal, append the line to the file path
so we can quick jump to the specific location.  Thanks to @vbatts for
the idea.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>