### PR TITLE
Dockerfile: pin to golang:1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-FROM golang:latest
+FROM golang:1.13
 
 ARG PROJECT=XXX
 ENV GOPATH /go
 WORKDIR /go/src/$PROJECT
-
-RUN go get -u github.com/LK4D4/vndr
-RUN go get -u golang.org/x/lint/golint


### PR DESCRIPTION
Pin the 1.13 and simplify it a bit more.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>