### PR TITLE
change line color from yellow to magenta

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -591,7 +591,7 @@ func (v *vgrep) commandPrintMatches(indices []int) bool {
 
 	cw := colwriter.New(4)
 	cw.Headers = true && !v.NoHeader
-	cw.Colors = []ansi.COLOR{ansi.YELLOW, ansi.BLUE, ansi.GREEN, ansi.DEFAULT}
+	cw.Colors = []ansi.COLOR{ansi.MAGENTA, ansi.BLUE, ansi.GREEN, ansi.DEFAULT}
 	cw.Padding = []colwriter.PaddingFunc{colwriter.PadLeft, colwriter.PadRight, colwriter.PadLeft, colwriter.PadNone}
 	cw.UseLess = !v.NoLess
 	cw.Trim = []bool{false, false, false, true}


### PR DESCRIPTION
Most terminal emulators use the tango colorscheme by default which has a
very bad contrast when using yellow rendering the lines column very hard
to read.  Change that to magenta to make it easier to read.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>