### PR TITLE
drop interactive -i short flag

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -30,7 +30,7 @@ import (
 // cliArgs passed to go-flags
 type cliArgs struct {
 	Debug       bool   `short:"d" long:"debug" description:"Verbose debug logging"`
-	Interactive bool   `short:"i" long:"interactive" description:"Enter interactive shell"`
+	Interactive bool   `long:"interactive" description:"Enter interactive shell"`
 	NoGit       bool   `long:"no-git" description:"Use grep instead of git-grep"`
 	NoHeader    bool   `long:"no-header" description:"Do not print pretty headers"`
 	NoLess      bool   `long:"no-less" description:"Use stdout instead of less"`


### PR DESCRIPTION
Drop the `-i` short flag for vgrep's interactive mode.  `-i` is already
in use by grep for case-insensitive search.

Fixes: #62
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>