### PR TITLE
Cache file mode 0644

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -352,7 +352,7 @@ func (v *vgrep) cacheWriterHelper() error {
 		}
 	}()
 
-	file, err := os.OpenFile(cache, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	file, err := os.OpenFile(cache, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Set cache file mode to 0644, it does not need to be executable.