### PR TITLE
Cross-platform `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ vendor:
 
 .PHONY: install
 install:
-	install -D -m755 $(BUILD_DIR)/$(NAME) $(BIN_DIR)
+	cp $(BUILD_DIR)/$(NAME) $(BIN_DIR)
+	chmod 755 $(BIN_DIR)$(NAME)
 
 .PHONY: uninstall
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ vendor:
 .PHONY: install
 install:
 	cp $(BUILD_DIR)/$(NAME) $(BIN_DIR)
-	chmod 755 $(BIN_DIR)$(NAME)
+	chmod 755 $(BIN_DIR)/$(NAME)
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
`install -D` is not available on BSDs and macOS.

AFAIK this `cp` + `chmod` approach will work the same way as `install -D`.