### PR TITLE
fix #79, define a new greptype bsd to select : seperator

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -241,7 +241,7 @@ func (v *vgrep) grep(args []string) {
 	}
 	v.matches = make([][]string, len(output))
 	for i, m := range output {
-		file, line, content := v.splitMatch(m, usegit, useripgrep, greptype)
+		file, line, content := v.splitMatch(m, greptype)
 		v.matches[i] = make([]string, 4)
 		v.matches[i][0] = strconv.Itoa(i)
 		v.matches[i][1] = file
@@ -254,8 +254,8 @@ func (v *vgrep) grep(args []string) {
 
 // splitMatch splits match into its file, line and content.  The format of
 // match varies depending if it has been produced by grep or git-grep.
-func (v *vgrep) splitMatch(match string, gitgrep bool, ripgrep bool, greptype string) (file, line, content string) {
-	if ripgrep {
+func (v *vgrep) splitMatch(match string, greptype string) (file, line, content string) {
+	if greptype == "RIP" {
 		// remove default color ansi escape codes from ripgrep's output
 		match = strings.Replace(match, "\x1b[0m", "", 4)
 	}

--- a/vgrep.go
+++ b/vgrep.go
@@ -191,7 +191,7 @@ func (v *vgrep) getGrepType() (grepType string) {
 	out, _ := v.runCommand([]string{"grep", "--version"}, "")
 	versionString := out[0]
 	// versionString = "grep (BSD grep) 2.5.1-FreeBSD"
-	versionRegex := regexp.MustCompile("\\(([[:alpha:]]+) grep\\)")
+	versionRegex := regexp.MustCompile(`\(([[:alpha:]]+) grep\)`)
 	// versionRegex matches to ["(BSD grep)", "BSD"], return "BSD"
 	grepType = versionRegex.FindStringSubmatch(versionString)[1]
 	return

--- a/vgrep.go
+++ b/vgrep.go
@@ -267,11 +267,10 @@ func (v *vgrep) splitMatch(match string, gitgrep bool, ripgrep bool, greptype st
 		seperator = []byte{0}
 	}
 	spl := bytes.SplitN([]byte(match), seperator, 3)
-
 	switch greptype {
-	case "BSD", "GIT", "GNU":
+	case "BSD", "GIT":
 		file, line, content = string(spl[0]), string(spl[1]), string(spl[2])
-	case "RIP":
+	case "GNU", "RIP":
 		splline := bytes.SplitN(spl[1], []byte(":"), 2)
 		file, line, content = string(spl[0]), string(splline[0]), string(splline[1])
 	}


### PR DESCRIPTION
based on the grep type select the seperator
and splitting format in splitMatch function

https://github.com/vrothberg/vgrep/issues/79