### PR TITLE
README: clarify search/show

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ vgrep can open matched lines in the editor specified by the `EDITOR` environment
 
 ![](screenshots/vgrep-show-gedit.png)
 
-Please note, as the default editor of vgrep is vim, the default flag to open a file at a specific line is ``+`` followed by the line number.  If your editor of choice hits the rare case of a different syntax, use the `EDITORLINEFLAG` environment variable to adjust.  For example, a `kate` user may set the environment to ``EDITOR="kate"`` and ``EDITORLINEFLAG="-l"``.
+The default editor of vgrep is `vim` with the default flag to open a file at a specific line is ``+`` followed by the line number.  If your editor of choice hits the rare case of a different syntax, use the `EDITORLINEFLAG` environment variable to adjust.  For example, a `kate` user may set the environment to ``EDITOR="kate"`` and ``EDITORLINEFLAG="-l"``.
+
+Note that `vgrep` does not allow for searching and opening files at the same time. For instance, if `vgrep --show=files text` should be two commands: `vgrep text` and `vgrep --show=files`.
 
 # vgrep commands and the interactive shell
 


### PR DESCRIPTION
Clarify that `vgrep` doesn't allow for searching and showing in one
command.  The technical reason for that is to allow for a more
user-friendly way of using the `--show` command.  In particular,
to support `--show x y z` with `x y z` all being arguments for --show
instead of `x` only.

Maybe there are workarounds with other flag-parsing libraries. Something
to look at in the future.

Fixes: #83
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>