### PR TITLE
vgrep: ignore non-matching lines

### DIFF
--- a/test/simple.bats
+++ b/test/simple.bats
@@ -68,3 +68,21 @@
 	rmdir $tmp
 	[[ ${lines[@]} =~ "grep -ZHInr" ]]
 }
+
+@test "Simple search with -A" {
+	run ./build/vgrep -A 1 test
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "0" ]]
+}
+
+@test "Simple search with -B" {
+	run ./build/vgrep -B 1 test
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "0" ]]
+}
+
+@test "Simple search with -C" {
+	run ./build/vgrep -B 1 test
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "0" ]]
+}


### PR DESCRIPTION
As reported in #84 `vgrep` panic'd when running with `-{A,B,C}` options
for grep.  These options print context lines and yield a different
format for the separator lines, which caused panics in the rather
optimistic parser.

Address the panics by ignoring lines that do not match the format. Those
lines will be skipped and can be found in the `--debug` log.

Fixes: #84
Reported-by: @marcosnils
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>