### PR TITLE
grep commands: Do not pass '.' as an argument to grep/ripgrep

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -232,7 +232,6 @@ func (v *vgrep) grep(args []string) {
 			"--color=always", "--no-heading", "--line-number",
 		}
 		cmd = append(cmd, args...)
-		cmd = append(cmd, ".")
 		greptype = RIPGrep
 	} else if usegit {
 		env = "HOME="
@@ -244,9 +243,8 @@ func (v *vgrep) grep(args []string) {
 		greptype = GITGrep
 	} else {
 		env = "GREP_COLORS='ms=01;31:mc=:sl=:cx=:fn=:ln=:se=:bn='"
-		cmd = []string{"grep", "-ZIn", "--color=always"}
+		cmd = []string{"grep", "-ZInr", "--color=always"}
 		cmd = append(cmd, args...)
-		cmd = append(cmd, "-r", ".")
 		greptype = v.getGrepType()
 	}
 	output, err := v.runCommand(cmd, env)


### PR DESCRIPTION
When building the grep or ripgrep commands to run, a dot (`.`) is appended to the list of arguments, to indicate that the current working directory should be searched recursively.

Both grep (with its `-r` option) and ripgrep already search the current working directory recursively if no other path is provided. Passing the dot:

- Is useless if no other path (file or directory) to search is provided.
- Adds the content of the whole directory to the list of the files to search, if files or directories were provided on the command line.

This is inconvenient for searching a subdirectory, for example. Typing `vgrep my_pattern foo/` will search for the pattern in files under `foo/` but also in all other files under the current directory, which may take longer and return undesired results.

This is also inconsistent with the behaviour for the `git grep` command, where only the arguments are passed and no `.` is appended.

Fix this by removing the dot appended to the command line. If desired, the former behaviour can be obtained by passing the working directory on the `vgrep` command line: `vgrep my_pattern foo/ .`.