### PR TITLE
git grep: Run 'git rev-parse' only if not selecting ripgrep

### DIFF
--- a/test/simple.bats
+++ b/test/simple.bats
@@ -41,3 +41,30 @@
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ "0" ]]
 }
+
+# Check that all grep tools are used when expected
+
+@test "Search with ripgrep" {
+	run ./build/vgrep -d some_pattern 2>&1
+	[[ ${lines[@]} =~ "rg -0" ]]
+}
+
+@test "Search with git grep" {
+	run ./build/vgrep -d --no-ripgrep some_pattern 2>&1
+	[[ ${lines[@]} =~ "git -c color.grep.match=red bold grep" ]]
+}
+
+@test "Search with classic grep" {
+	run ./build/vgrep -d --no-ripgrep --no-git some_pattern 2>&1
+	[[ ${lines[@]} =~ "grep -ZHInr" ]]
+}
+
+@test "Fallback to classic grep with --no-ripgrep and outside of a git repo" {
+	tmp=$(mktemp -d)
+	vgrep_repo="$PWD"
+	pushd $tmp
+	run "$vgrep_repo"/build/vgrep -d --no-ripgrep some_pattern 2>&1
+	popd
+	rmdir $tmp
+	[[ ${lines[@]} =~ "grep -ZHInr" ]]
+}

--- a/vgrep.go
+++ b/vgrep.go
@@ -220,13 +220,10 @@ func isVscode() bool {
 // grep (git) greps with the specified args and stores the results in v.matches.
 func (v *vgrep) grep(args []string) {
 	var cmd []string
-	var usegit bool
 	var env string
 	var greptype string // can have values , GIT, RIP, GNU, BSD
 
-	useripgrep := v.ripgrepInstalled() && !v.NoRipgrep
-	usegit = v.insideGitTree() && !v.NoGit
-	if useripgrep {
+	if v.ripgrepInstalled() && !v.NoRipgrep {
 		cmd = []string{
 			"rg", "-0", "--colors=path:none", "--colors=line:none",
 			"--color=always", "--no-heading", "--line-number",
@@ -234,7 +231,7 @@ func (v *vgrep) grep(args []string) {
 		}
 		cmd = append(cmd, args...)
 		greptype = RIPGrep
-	} else if usegit {
+	} else if v.insideGitTree() && !v.NoGit {
 		env = "HOME="
 		cmd = []string{
 			"git", "-c", "color.grep.match=red bold",


### PR DESCRIPTION
A third one :).

Vgrep always runs `git rev-parse` to check whether the current directory is a git repository. This is useless if ripgrep is installed, since it is picked by default. Let's run git only if ripgrep is not selected.

Add some tests to check that all expected grep tools are picked, depending on the circumstances. They rely on the debug output to inspect what command is run.