### PR TITLE
delete: fix index update for multi-line deletions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ vgrep supports the following commands:
 - ``show`` to open the selectors in an user-specified editor (requires selectors).
 - ``context`` to print the context lines before and after the matched lines. ``c10 3-9`` prints 10 context lines of the matching lines 3 to 9.  Unless specified, vgrep will print 5 context lines.
 - ``tree`` to print the number of matches for each directory in the tree.
+- ``delete`` to remove lines at selected indices from the results, for the duration of the interactive shell (requires selectors).
 - ``files`` will print the number of matches for each file in the tree.
 - ``quit`` to exit the interactive shell.
 - ``?`` to show the help for vgrep commands.

--- a/test/interactive.bats
+++ b/test/interactive.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats -t
+
+@test "Interactive mode and delete with selectors" {
+	./build/vgrep peanut test/search_files/foobar.txt > /dev/null
+	run ./build/vgrep --show d 1,2-3,5,7-9,8-10 --interactive --no-header << EOF
+p
+q
+EOF
+	# Current shell returns 1 in this case, skip status check
+	#[ "$status" -eq 0 ]
+	# We expect 3 results, but there is also a prompt line in the output
+	[[ ${#lines[*]} -eq 4 ]]
+	[[ ${lines[0]} =~ "zero" ]]
+	[[ ${lines[1]} =~ "four" ]]
+	[[ ${lines[2]} =~ "six" ]]
+}

--- a/test/search_files/foobar.txt
+++ b/test/search_files/foobar.txt
@@ -1,1 +1,12 @@
 foo bar baz
+zero peanut
+one peanut
+two peanuts
+three peanuts
+four peanuts
+five peanuts
+six peanuts
+seven peanuts
+eight peanuts
+nine peanuts
+ten peanuts

--- a/vgrep.go
+++ b/vgrep.go
@@ -799,7 +799,7 @@ func (v *vgrep) commandDelete(indices []int) bool {
 		for i := idx + 1; i < len(v.matches); i++ {
 			v.matches[i][0] = strconv.Itoa(i - 1)
 		}
-		index := idx + offset
+		index := idx - offset
 		v.matches = append(v.matches[:index], v.matches[index+1:]...)
 	}
 


### PR DESCRIPTION
The operation used to update the index when deleting a selection of lines is incorrect. Deletions are done sequentially, so after the first deletion, the indices in the list of results have changed and we need to take that into account. But each time we remove an entry, the list of results _shrinks_ by one, so we want a _smaller_ index. The addition in `index := idx + offset` is wrong, it should be a subtraction. Let's fix.

Add a test to validate the results, and document the missing `delete` command in the README.md.

As a side note I initially wrote the test on top of the readline-lib set before rebasing for a clean PR, and it turns out the readline makes it somewhat easier to pass input to vgrep for the tests. In particular, the heredoc accepts more than one line (currently, the `q` is actually ignored), and the readline does not print a prompt when reading from a pipe or a heredoc but it does exit cleanly with a `0` return code.