### PR TITLE
Add new "keep" and "refine" commands to the interactive shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Once vgreped, you can perform certain operations on the results such as limiting
 Enter a vgrep command: ?
 vgrep command help: command[context lines] [selectors]
          selectors: '3' (single), '1,2,6' (multi), '1-8' (range)
-          commands: print, show, context, tree, delete, keep, files, quit, ?
+          commands: print, show, context, tree, delete, keep, refine, files, quit, ?
 ```
 vgrep commands can be passed directly to the ``--show/-s`` flag, for instance as ``--show c5 1-10`` to show the five context lines of the first ten matched lines.  Furthermore, the commands can be executed in an interactive shell via the ``--interactive/-i`` flag. Running ``vgrep --interactive`` will enter the shell directly, ``vgrep --show 1 --interactive`` will first open the first matched line in the editor and enter the interactive shell after.
 
@@ -53,6 +53,7 @@ vgrep supports the following commands:
 - ``tree`` to print the number of matches for each directory in the tree.
 - ``delete`` to remove lines at selected indices from the results, for the duration of the interactive shell (requires selectors).
 - ``keep`` to keep only lines at selected indices from the results, for the duration of the interactive shell (requires selectors).
+- ``refine`` to keep only lines matching the provided regexp pattern from the results, for the duration of the interactive shell (requires a regexp string).
 - ``files`` will print the number of matches for each file in the tree.
 - ``quit`` to exit the interactive shell.
 - ``?`` to show the help for vgrep commands.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Once vgreped, you can perform certain operations on the results such as limiting
 Enter a vgrep command: ?
 vgrep command help: command[context lines] [selectors]
          selectors: '3' (single), '1,2,6' (multi), '1-8' (range)
-          commands: print, show, context, tree, delete, files, quit, ?
+          commands: print, show, context, tree, delete, keep, files, quit, ?
 ```
 vgrep commands can be passed directly to the ``--show/-s`` flag, for instance as ``--show c5 1-10`` to show the five context lines of the first ten matched lines.  Furthermore, the commands can be executed in an interactive shell via the ``--interactive/-i`` flag. Running ``vgrep --interactive`` will enter the shell directly, ``vgrep --show 1 --interactive`` will first open the first matched line in the editor and enter the interactive shell after.
 
@@ -52,6 +52,7 @@ vgrep supports the following commands:
 - ``context`` to print the context lines before and after the matched lines. ``c10 3-9`` prints 10 context lines of the matching lines 3 to 9.  Unless specified, vgrep will print 5 context lines.
 - ``tree`` to print the number of matches for each directory in the tree.
 - ``delete`` to remove lines at selected indices from the results, for the duration of the interactive shell (requires selectors).
+- ``keep`` to keep only lines at selected indices from the results, for the duration of the interactive shell (requires selectors).
 - ``files`` will print the number of matches for each file in the tree.
 - ``quit`` to exit the interactive shell.
 - ``?`` to show the help for vgrep commands.

--- a/test/interactive.bats
+++ b/test/interactive.bats
@@ -1,8 +1,24 @@
 #!/usr/bin/env bats -t
 
+FILE=test/search_files/foobar.txt
+
 @test "Interactive mode and delete with selectors" {
-	./build/vgrep peanut test/search_files/foobar.txt > /dev/null
+	./build/vgrep peanut $FILE > /dev/null
 	run ./build/vgrep --show d 1,2-3,5,7-9,8-10 --interactive --no-header << EOF
+p
+q
+EOF
+	[ "$status" -eq 0 ]
+	# We expect 3 results, but there is also a prompt line in the output
+	[[ ${#lines[*]} -eq 4 ]]
+	[[ ${lines[0]} =~ "zero" ]]
+	[[ ${lines[1]} =~ "four" ]]
+	[[ ${lines[2]} =~ "six" ]]
+}
+
+@test "Interactive mode and keep with selectors" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --show k 0,4,6 --interactive --no-header << EOF
 p
 q
 EOF

--- a/test/interactive.bats
+++ b/test/interactive.bats
@@ -29,3 +29,17 @@ EOF
 	[[ ${lines[1]} =~ "four" ]]
 	[[ ${lines[2]} =~ "six" ]]
 }
+
+@test "Interactive mode and refine with regexp" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --show r '(zero|f[^i].* p|six)' --interactive --no-header << EOF
+p
+q
+EOF
+	[ "$status" -eq 0 ]
+	# We expect 3 results, but there is also a prompt line in the output
+	[[ ${#lines[*]} -eq 4 ]]
+	[[ ${lines[0]} =~ "zero" ]]
+	[[ ${lines[1]} =~ "four" ]]
+	[[ ${lines[2]} =~ "six" ]]
+}

--- a/vgrep.go
+++ b/vgrep.go
@@ -605,6 +605,14 @@ func (v *vgrep) dispatchCommand(input string) bool {
 		return v.commandDelete(indices)
 	}
 
+	if command == "k" || command == "keep" {
+		if len(indices) == 0 {
+			fmt.Println("keep requires specified selectors")
+			return false
+		}
+		return v.commandKeep(indices)
+	}
+
 	if command == "f" || command == "files" {
 		return v.commandListFiles(indices)
 	}
@@ -640,9 +648,10 @@ func (v *vgrep) dispatchCommand(input string) bool {
 func (v *vgrep) commandPrintHelp() bool {
 	fmt.Printf("vgrep command help: command[context lines] [selectors]\n")
 	fmt.Printf("         selectors: '3' (single), '1,2,6' (multi), '1-8' (range)\n")
-	fmt.Printf("          commands: %srint, %show, %sontext, %sree, %selete, %siles, %suit, %s\n",
+	fmt.Printf("          commands: %srint, %show, %sontext, %sree, %selete, %seep, %siles, %suit, %s\n",
 		ansi.Bold("p"), ansi.Bold("s"), ansi.Bold("c"), ansi.Bold("t"),
-		ansi.Bold("d"), ansi.Bold("f"), ansi.Bold("q"), ansi.Bold("?"))
+		ansi.Bold("d"), ansi.Bold("k"), ansi.Bold("f"), ansi.Bold("q"),
+		ansi.Bold("?"))
 	return false
 }
 
@@ -805,6 +814,24 @@ func (v *vgrep) commandDelete(indices []int) bool {
 	}
 
 	return false
+}
+
+// commandKeep does the opposite of commandDelete and keeps only provided
+// indices in v.matches.
+func (v *vgrep) commandKeep(indices []int) bool {
+	var toDelete []int
+	var last int
+
+	for _, idx := range indices {
+		for i := last; i < idx; i++ {
+			toDelete = append(toDelete, i)
+		}
+		last = idx + 1
+	}
+	for i := last; i < len(v.matches); i++ {
+		toDelete = append(toDelete, i)
+	}
+	return v.commandDelete(toDelete)
 }
 
 // commandShow opens the environment's editor at v.matches[index].

--- a/vgrep.go
+++ b/vgrep.go
@@ -551,6 +551,18 @@ func (v *vgrep) dispatchCommand(input string) bool {
 		return v.commandPrintHelp()
 	}
 
+	// Deal first with "refine" because for all other commands (below) we
+	// assume that any argument is provided as a set of selectors on
+	// indices. "refine" expects a regexp.
+	cmdArray := strings.SplitN(input, " ", 2)
+	if cmdArray[0] == "r" || cmdArray[0] == "refine" {
+		if len(cmdArray) != 2 {
+			fmt.Println("refine expects a regexp argument")
+			return false
+		}
+		return v.commandRefine(cmdArray[1])
+	}
+
 	// normalize selector-only inputs (e.g., "1,2,3,5-10") to the show cmd
 	numRgx := regexp.MustCompile(`^([\d]+){0,1}([\d , -]+){0,1}$`)
 	if numRgx.MatchString(input) {
@@ -566,7 +578,7 @@ func (v *vgrep) dispatchCommand(input string) bool {
 	var command, selectors string
 	var context int
 
-	cmdArray := cmdRgx.FindStringSubmatch(input)
+	cmdArray = cmdRgx.FindStringSubmatch(input)
 	command = cmdArray[1]
 	selectors = cmdArray[3]
 	context = -1
@@ -648,10 +660,10 @@ func (v *vgrep) dispatchCommand(input string) bool {
 func (v *vgrep) commandPrintHelp() bool {
 	fmt.Printf("vgrep command help: command[context lines] [selectors]\n")
 	fmt.Printf("         selectors: '3' (single), '1,2,6' (multi), '1-8' (range)\n")
-	fmt.Printf("          commands: %srint, %show, %sontext, %sree, %selete, %seep, %siles, %suit, %s\n",
+	fmt.Printf("          commands: %srint, %show, %sontext, %sree, %selete, %seep, %sefine, %siles, %suit, %s\n",
 		ansi.Bold("p"), ansi.Bold("s"), ansi.Bold("c"), ansi.Bold("t"),
-		ansi.Bold("d"), ansi.Bold("k"), ansi.Bold("f"), ansi.Bold("q"),
-		ansi.Bold("?"))
+		ansi.Bold("d"), ansi.Bold("k"), ansi.Bold("r"), ansi.Bold("f"),
+		ansi.Bold("q"), ansi.Bold("?"))
 	return false
 }
 
@@ -830,6 +842,24 @@ func (v *vgrep) commandKeep(indices []int) bool {
 	}
 	for i := last; i < len(v.matches); i++ {
 		toDelete = append(toDelete, i)
+	}
+	return v.commandDelete(toDelete)
+}
+
+// commandRefine deletes all results that do not match the provided pattern
+// (regexp) from the list.
+func (v *vgrep) commandRefine(expr string) bool {
+	pattern, err := regexp.Compile(expr)
+	if err != nil {
+		fmt.Printf("failed to compile '%s' as a regexp\n", expr)
+		return false
+	}
+
+	var toDelete []int
+	for offset, grepMatch := range v.matches {
+		if !pattern.Match([]byte(ansi.RemoveANSI(grepMatch[3]))) {
+			toDelete = append(toDelete, offset)
+		}
 	}
 	return v.commandDelete(toDelete)
 }


### PR DESCRIPTION
This PR adds two new commands for further filtering the results in the interactive shell:

- `k`/`keep` does the opposite of `delete`: It keeps only the results for provided indices. Might be useful for keeping a small subset of results, or for filtering on given file (since results are sorted per file, it should be easy to provide a range for the desired file).
- `r`/`refine` restricts the list of results to those matching the provided regular expression.