### PR TITLE
Miscellaneous fixes

### DIFF
--- a/internal/colwriter/colwriter.go
+++ b/internal/colwriter/colwriter.go
@@ -124,6 +124,9 @@ func (cw *ColWriter) Write(rows [][]string) {
 		panic("Write() on unopened ColWriter\n")
 	}
 	cw.ComputeSize(rows)
+	if len(rows) == 0 {
+		return
+	}
 	max := len(rows[0]) - 1
 
 	if cw.Headers {

--- a/vgrep.go
+++ b/vgrep.go
@@ -842,7 +842,7 @@ func (v *vgrep) commandShow(index int) bool {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		fmt.Printf("douldn't open index %d: %v\n", index, err)
+		fmt.Printf("couldn't open index %d: %v\n", index, err)
 	}
 
 	return false

--- a/vgrep.go
+++ b/vgrep.go
@@ -506,6 +506,7 @@ func (v *vgrep) commandParse() {
 		usrInp, err := line.Prompt("Enter a vgrep command: ")
 		if err != nil {
 			// Either we hit an error or EOF (ctrl+d)
+			line.Close()
 			fmt.Fprintf(os.Stderr, "error parsing user input: %v\n", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
Having three different fixes to push, I thought they would deserve their own PR after all.

- Fix the command-line editor not being closed on early `os.Exit()` (#106).
- Fix a crash in `colwriter` with `--no-header` if there is no result to print.
- Fix a typo.