### PR TITLE
splitMatch: fail gracefully on failure to parse output

### DIFF
--- a/test/simple.bats
+++ b/test/simple.bats
@@ -68,3 +68,12 @@
 	rmdir $tmp
 	[[ ${lines[@]} =~ "grep -ZHInr" ]]
 }
+
+# Other checks
+
+@test "Fail gracefully with error message when unable to parse output" {
+	run ./build/vgrep -d -C5 peanut
+	[ "$status" -eq 1 ]
+	[[ ${lines[@]} =~ "failed to parse results, did you use an option that modifies the output?" ]]
+	[[ ${lines[@]} =~ "level=debug msg=\"failed to parse:" ]]
+}


### PR DESCRIPTION
Vgrep may fail to parse the output from the selected grep tool, in particular if the user provided some options that modify the output (`-A`, `-B`, `-C`, `-a`, ...). In such a case, splitting the results on the separators will not produce the expected number of substrings and will result in attempts to access incorrect indices in the slice.

Fix `splitMatch()` so vgrep exits gracefully with a hint message when it cannot parse the output.

Add a test for this case.