### PR TITLE
selectors: add a "all" selector to process all results

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Once vgreped, you can perform certain operations on the results such as limiting
 ```
 Enter a vgrep command: ?
 vgrep command help: command[context lines] [selectors]
-         selectors: '3' (single), '1,2,6' (multi), '1-8' (range)
+         selectors: '3' (single), '1,2,6' (multi), '1-8' (range), 'all'
           commands: print, show, context, tree, delete, keep, refine, files, grep, quit, ?
 ```
 vgrep commands can be passed directly to the ``--show/-s`` flag, for instance as ``--show c5 1-10`` to show the five context lines of the first ten matched lines.  Furthermore, the commands can be executed in an interactive shell via the ``--interactive/-i`` flag. Running ``vgrep --interactive`` will enter the shell directly, ``vgrep --show 1 --interactive`` will first open the first matched line in the editor and enter the interactive shell after.

--- a/test/selectors.bats
+++ b/test/selectors.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats -t
+
+FILE=test/search_files/foobar.txt
+
+@test "Selectors: discrete selection" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --no-header --show p 0,1,2,3,4
+	[ "$status" -eq 0 ]
+	[[ ${#lines[*]} -eq 5 ]]
+	[[ ${lines[4]} =~ "four" ]]
+}
+
+@test "Selectors: range" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --no-header --show p 0-4
+	[ "$status" -eq 0 ]
+	[[ ${#lines[*]} -eq 5 ]]
+	[[ ${lines[4]} =~ "four" ]]
+}
+
+@test "Selectors: mix" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --no-header --show p 0-4,5,8
+	[ "$status" -eq 0 ]
+	[[ ${#lines[*]} -eq 7 ]]
+	[[ ${lines[4]} =~ "four" ]]
+}
+
+@test "Selectors: mix, with spaces" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --no-header --show p 0 - 4, 5, 8
+	[ "$status" -eq 0 ]
+	[[ ${#lines[*]} -eq 7 ]]
+	[[ ${lines[4]} =~ "four" ]]
+}
+
+@test "Selectors: context with print (no effect)" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --no-header --show p3 0-4
+	[ "$status" -eq 0 ]
+	[[ ${#lines[*]} -eq 5 ]]
+	[[ ${lines[4]} =~ "four" ]]
+}
+
+@test "Selectors: context with range" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --show c2 2-4
+	[ "$status" -eq 0 ]
+	[[ ${#lines[*]} -eq 18 ]]
+	[[ ${lines[15]} =~ "four" ]]
+}
+
+@test "Selectors: empty selection" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --no-header --show p
+	[ "$status" -eq 0 ]
+	[[ ${#lines[*]} -eq 11 ]]
+	[[ ${lines[4]} =~ "four" ]]
+}
+
+@test "Selectors: all" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --no-header --show p all
+	[ "$status" -eq 0 ]
+	[[ ${#lines[*]} -eq 11 ]]
+	[[ ${lines[4]} =~ "four" ]]
+}
+
+@test "Selectors: index out of range" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --no-header --show p 999
+	[ "$status" -eq 0 ]
+	[[ ${#lines[*]} -eq 1 ]]
+	[[ ${lines[@]} =~ "out of range" ]]
+}
+
+@test "Selectors: range out of range" {
+	./build/vgrep peanut $FILE > /dev/null
+	run ./build/vgrep --no-header --show p 0-999
+	[ "$status" -eq 0 ]
+	[[ ${#lines[*]} -eq 1 ]]
+	[[ ${lines[@]} =~ "out of range" ]]
+}


### PR DESCRIPTION
Some vgrep commands (`print`, `context` for example) defaults to processing all search results if no selector is passed. Some other commands (`show`, `delete`) are slightly more sensitive, and they require an explicit set of selectors to indicate the entries to process.

For some commands (`show` in particular), it could be interesting to have a shortcut to tell them “do process all entries, I know what I am doing”. This PR implements a new selector, `all`, that does just that.

A new test file is added to check that selectors are parsed as expected.