### PR TITLE
make build: rm `-dev` prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all: check build
 
 .PHONY: build
 build: $(GO_SRC)
-	$(GO_BUILD) -buildmode=pie -o $(BUILD_DIR)/$(NAME) -ldflags "-s -w -X main.version=${VERSION}-$(COMMIT)-dev"
+	$(GO_BUILD) -buildmode=pie -o $(BUILD_DIR)/$(NAME) -ldflags "-s -w -X main.version=${VERSION}-$(COMMIT)"
 
 .PHONY: release
 release: $(GO_SRC)


### PR DESCRIPTION
Remove the `-dev` prefix from `make build` as the VERSION file covers
that now.  Now it's easier to detect a dev version.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>