### PR TITLE
main: exit with 1 if no line is selected

### DIFF
--- a/test/simple.bats
+++ b/test/simple.bats
@@ -79,3 +79,16 @@ load helpers
 	[[ ${lines[@]} =~ "failed to parse results, did you use an option that modifies the output?" ]]
 	[[ ${lines[@]} =~ "level=debug msg=\"failed to parse:" ]]
 }
+
+@test "Exit with 1 when a search has no matches" {
+	run_vgrep "^cashew$"
+	[ "$status" -eq 1 ]
+	[[ ${#lines[*]} -eq 0 ]]
+}
+
+@test "Exit with 1 when operating on empty results" {
+	run_vgrep "^cashew$" > /dev/null
+	run_vgrep
+	[ "$status" -eq 1 ]
+	[[ ${#lines[*]} -eq 0 ]]
+}

--- a/vgrep.go
+++ b/vgrep.go
@@ -122,29 +122,29 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error loading cache: %v\n", err)
 			os.Exit(1)
 		}
-	} else {
-		v.waiter.Add(1)
-		v.grep(args)
-		v.cacheWrite() // this runs in the background
-	}
 
-	if len(v.matches) == 0 {
-		os.Exit(0) // nothing to do anymore
-	}
+		if len(v.matches) == 0 {
+			os.Exit(1)
+		}
 
-	// Execute the specified command and/or jump directly into the
-	// interactive shell.
-	if haveToRunCommand {
+		// Execute the specified command and/or jump directly into the
+		// interactive shell.
 		v.commandParse()
 		v.waiter.Wait()
 		os.Exit(0)
 	}
 
-	// Last resort, print all matches.
-	if len(v.matches) > 0 {
-		v.commandPrintMatches([]int{})
+	v.waiter.Add(1)
+	v.grep(args)
+	v.cacheWrite() // this runs in the background
+
+	if len(v.matches) == 0 {
+		v.waiter.Wait()
+		os.Exit(1)
 	}
 
+	// Last resort, print all matches.
+	v.commandPrintMatches([]int{})
 	v.waiter.Wait()
 }
 


### PR DESCRIPTION
This mimics the behavior of grep/git-grep and ripgrep, and is useful for chaining a search with a later command:

    vgrep "matches zero lines" && vgrep --interactive

As an implementation detail, this commit also reworks the final stages of `main()`, for two reasons:

- to more easily handle in which cases it is necessary to `Wait()`;
- to fix a probable (though not confirmed)[1] bug where a search that resulted in 0 matches would cause the behavior of later commands to be undefined, due to `cacheWrite` not necessarily completing before the program terminated.

[1] In a simple test `cacheWrite` does not complete and leaves the previous search results in place.