### PR TITLE
Add goreleaser config to ship statis binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+before:
+  hooks:
+    - go mod download
+build:
+  goos:
+    - darwin
+    - linux
+    - windows
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+  format: binary
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'


### PR DESCRIPTION
This PR adds `goreleaser` support to release static binaries. 

I couldn't find the script that actually releases the project in the repo so I'm just adding this here. In order to release the project using goreleaser, you just need to download the [goreleaser](https://goreleaser.com/install/) tool and run `export GITHUB_TOKEN=$MYTOKEN goreleaser`. 

The above command will automatically perform the release in github, publish the binaries and generate a changelog.