### PR TITLE
Handle SIGINT

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -75,6 +75,8 @@ func main() {
 		v   vgrep
 	)
 
+	// vgrep must not be terminated with SIGINT since less pager must be
+	// terminated before vgrep. Ignore SIGINT.
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, os.Interrupt)
 	go func() {

--- a/vgrep.go
+++ b/vgrep.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -73,6 +74,13 @@ func main() {
 		err error
 		v   vgrep
 	)
+
+	sc := make(chan os.Signal, 1)
+	signal.Notify(sc, os.Interrupt)
+	go func() {
+		for range sc {
+		}
+	}()
 
 	// Unknown flags will be ignored and stored in args to further pass them
 	// to (git) grep.


### PR DESCRIPTION
When running pager (less) and type CTRL-C, less is not terminated on Windows. I think vgrep should block CTLR-C.