### PR TITLE
support Goland

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The default editor of vgrep is `vim` with the default flag to open a file at a s
 
 Note that `vgrep` does not allow for searching and opening files at the same time. For instance, `vgrep --show=files text` should be split in two commands: `vgrep text` and `vgrep --show=files`.
 
+## IDE Support
+
+Note that if you run `vgrep` inside a terminal of VSCode or Goland, the format of listed files changes to "$PATH:$LINE" to allow for opening the matches in the editor via a simple mouse click.
+
 # More Commands and the Interactive Shell
 
 Once vgreped, you can perform certain operations on the results such as limiting the range of indexed matches, listing matching files and directories and more.

--- a/docs/vgrep.1.md
+++ b/docs/vgrep.1.md
@@ -35,6 +35,11 @@ The default editor of vgrep is `vim` with the default flag to open a file at a s
 
 Note that `vgrep` does not allow for searching and opening files at the same time. For instance, `vgrep --show=files text` should be split in two commands: `vgrep text` and `vgrep --show=files`.
 
+### IDE Support
+
+Note that if you run `vgrep` inside a terminal of VSCode or Goland, the format of listed files changes to "$PATH:$LINE" to allow for opening the matches in the editor via a simple mouse click.
+
+
 ## Interactive Shell
 
 Once vgreped, you can perform certain operations on the results such as limiting the range of indexed matches, listing matching files and directories and more.

--- a/vgrep.go
+++ b/vgrep.go
@@ -234,6 +234,11 @@ func isVscode() bool {
 	return os.Getenv("TERM_PROGRAM") == "vscode"
 }
 
+// isGoland checks if the terminal is running inside of goland or possible other JetBrains IDEs.
+func isGoland() bool {
+	return strings.Contains(os.Getenv("TERMINAL_EMULATOR"), "JetBrains")
+}
+
 // grep (git) greps with the specified args and stores the results in v.matches.
 func (v *vgrep) grep(args []string) {
 	var cmd []string
@@ -777,13 +782,14 @@ func (v *vgrep) commandPrintMatches(indices []int) bool {
 		toPrint = append(toPrint, []string{"Index", "File", "Line", "Content"})
 	}
 
-	isVscode := isVscode()
+	inIDE := isVscode() || isGoland()
 	for _, i := range indices {
-		if isVscode {
-			// If we're running inside a vscode terminal, append the line to the
-			// file path, so we can quick jump to the specific location.  Note
-			// that dancing around with the indexes below is intentional - ugly
-			// but fast.
+		if inIDE {
+			// If we're running inside an IDE's terminal, append
+			// the line to the file path, so we can quick jump to
+			// the specific location.  Note that dancing around
+			// with the indexes below is intentional - ugly but
+			// fast.
 			toPrint = append(toPrint, []string{v.matches[i][0], v.matches[i][1] + ":" + v.matches[i][2], v.matches[i][2], v.matches[i][3]})
 		} else {
 			toPrint = append(toPrint, v.matches[i])


### PR DESCRIPTION
Change the file format to "$PATH:$LINE" when running inside a Goland
terminal.  `vgrep` already supports VSCode so drop a section to the
README to better communicate this behavior.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>