### PR TITLE
vgrep [no grep args]: print matches

### DIFF
--- a/test/simple.bats
+++ b/test/simple.bats
@@ -18,10 +18,18 @@ load helpers
 	run_vgrep --no-git f
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ "0" ]]
+
+	run_vgrep
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "0" ]]
 }
 
 @test "Simple search and --no-ripgrep" {
 	run_vgrep --no-ripgrep f
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "0" ]]
+
+	run_vgrep
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ "0" ]]
 }
@@ -30,16 +38,28 @@ load helpers
 	run_vgrep --no-git --no-ripgrep f
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ "0" ]]
+
+	run_vgrep
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "0" ]]
 }
 
 @test "Simple search and --no-header" {
 	run_vgrep --no-header f
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ "0" ]]
+
+	run_vgrep
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "0" ]]
 }
 
 @test "Simple search and --no-less" {
 	run_vgrep --no-less f
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "0" ]]
+
+	run_vgrep --no-less
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ "0" ]]
 }

--- a/vgrep.go
+++ b/vgrep.go
@@ -137,9 +137,11 @@ func main() {
 			os.Exit(1)
 		}
 
-		// Execute the specified command and/or jump directly into the
-		// interactive shell.
-		v.commandParse()
+		if haveToRunCommand {
+			v.commandParse()
+		} else {
+			v.commandPrintMatches([]int{})
+		}
 		v.waiter.Wait()
 		os.Exit(0)
 	}


### PR DESCRIPTION
`vgrep` should print previously cached results when it's run without
grep arguments.  At some yet unknown point in time, we regressed on
it which is calling for regression tests that are now added

Fixes: #132
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>