### PR TITLE
Fix fzf example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ vgrep() {
   INITIAL_QUERY="$1"
   VGREP_PREFIX="vgrep --no-header "
   FZF_DEFAULT_COMMAND="$VGREP_PREFIX '$INITIAL_QUERY'" \
-  | fzf --bind "change:reload:$VGREP_PREFIX {q} || true" --phony --tac --query "$INITIAL_QUERY" \
+    fzf --bind "change:reload:$VGREP_PREFIX {q} || true" --ansi --phony --tac --query "$INITIAL_QUERY" \
   | awk '{print $1}' | xargs -I{} -o vgrep --show {}
 }
 ```


### PR DESCRIPTION
* Interpret ANSI escape sequences to show colors in fzf by using the `--ansi` flag
* Fix syntax error (pipe operator before fzf invocation)

This should fix the remaining issues from https://github.com/vrothberg/vgrep/pull/143