### PR TITLE
add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Already used in the containers organization to further automate keeping
dependencies up to date as it now allows for updating `vendor/` tree as
well.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>