### PR TITLE
Dockerfile: also use golang:1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.17
 
 ARG PROJECT=XXX
 ENV GOPATH /go


### PR DESCRIPTION
In addition to the CI, the build process inside a container should also use a recent Go release.

Signed-off-by: Andreas Ziegler <andreas.ziegler@fau.de>