### PR TITLE
Fix RegEx for grep type

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -259,7 +259,8 @@ func (v *vgrep) getGrepType() (grepType string) {
 	out, _ := v.runCommand([]string{"grep", "--version"}, "")
 	versionString := out[0]
 	// versionString = "grep (BSD grep) 2.5.1-FreeBSD"
-	versionRegex := regexp.MustCompile(`\(([[:alpha:]]+) grep\)`)
+	// versionString = "grep (BSD grep, GNU compatible) 2.6.0-FreeBSD"
+	versionRegex := regexp.MustCompile(`\(([[:alpha:]]+) grep`)
 	// versionRegex matches to ["(BSD grep)", "BSD"], return "BSD"
 	grepType = versionRegex.FindStringSubmatch(versionString)[1]
 	return


### PR DESCRIPTION
This PR fixes compatibility issues with `grep` on macOS.
Because macOS uses `grep (BSD grep, GNU compatible) 2.6.0-FreeBSD`, the RegEx for detecting the version doesn't work as expected.
I therefore removed the matching of the closing bracket (`)`) and added this different version string as a comment.

Before:
```
# vgrep -w "Homebrew" --no-less .          
panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
main.(*vgrep).getGrepType(0x6542da0)
        /private/tmp/vgrep-20211031-92807-9uidb/vgrep-2.5.3/vgrep.go:264 +0xc8
main.(*vgrep).grep(0xc0000f8000, {0xc00007a040, 0x3, 0x4})
        /private/tmp/vgrep-20211031-92807-9uidb/vgrep-2.5.3/vgrep.go:304 +0x43b
main.main()
        /private/tmp/vgrep-20211031-92807-9uidb/vgrep-2.5.3/vgrep.go:184 +0x765
```
After (expected result):
```
# vgrep -w "Homebrew" --no-less .
Index File         Line Content
    0 ./test.txt:1    1 Hello from Homebrew
```