### PR TITLE
-l, --files-with-matches

### DIFF
--- a/test/simple.bats
+++ b/test/simple.bats
@@ -64,6 +64,12 @@ load helpers
 	[[ ${lines[0]} =~ "0" ]]
 }
 
+@test "Simple search and --files-with-matches" {
+	run_vgrep --files-with-matches Valentin vgrep.go
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "vgrep.go" ]]
+}
+
 # Check that all grep tools are used when expected
 
 @test "Search with ripgrep" {


### PR DESCRIPTION
Add an option to print the names of matching files in their relative
order.

Closes: #150
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>