### PR TITLE
Fix 'git grep' color issue reported in Issue #169

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -301,7 +301,7 @@ func (v *vgrep) grep(args []string) {
 		env = "HOME="
 		cmd = []string{
 			"git", "-c", "color.grep.match=red bold",
-			"grep", "-z", "-In", "--color=always",
+			"grep", "-z", "-In", "--color=auto",
 		}
 		cmd = append(cmd, args...)
 		greptype = GITGrep


### PR DESCRIPTION
It should be "--color=auto" not "--color=always" as newer versions of
git will really set the output to color even if it is a pipe like is
happening in vgrep.

Fixes a regression in not working properly with newer versions of git.

Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>