### PR TITLE
make .install.go-md2man: use go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ vendor:
 
 .install.go-md2man:
 ifeq ($(GOMD2MAN),)
-	$(GO) get github.com/cpuguy83/go-md2man
+	$(GO) install github.com/cpuguy83/go-md2man
 endif
 
 .PHONY: install


### PR DESCRIPTION
Starting with v1.17 `go get` does not install binaries anymore [1],
so use `go install` instead;  Go < v1.17 has been archived.

[1] https://go.dev/doc/go-get-install-deprecation

Fixes: #172
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>