### PR TITLE
allow ripgrep to use configuration file

### DIFF
--- a/vgrep.go
+++ b/vgrep.go
@@ -297,6 +297,10 @@ func (v *vgrep) grep(args []string) {
 		}
 		cmd = append(cmd, args...)
 		greptype = RIPGrep
+		config := os.Getenv("RIPGREP_CONFIG_PATH")
+		if len(config) != 0 {
+			env = "RIPGREP_CONFIG_PATH=" + config
+		}
 	} else if v.insideGitTree() && !v.NoGit {
 		env = "HOME="
 		cmd = []string{


### PR DESCRIPTION
Check for the ripgrep configuration file path env variable and pass it
if it exists.

https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file