### PR TITLE
Add environment variable to switch the order of LINEFLAG and file

### DIFF
--- a/test/editor.bats
+++ b/test/editor.bats
@@ -54,3 +54,15 @@ load helpers
 	[[ ${args[0]} =~ .*/editor.bats ]]
 	[[ ${args[1]} == -l5 ]]
 }
+
+@test "EDITORLINEFLAGREVERSED" {
+	run_vgrep test test/editor.bats
+	[ "$status" -eq 0 ]
+	unset EDITOR
+	export EDITORLINEFLAGREVERSED=1
+	run_vgrep -s 0
+	[ "$status" -eq 0 ]
+	args=(${lines[1]})
+	[[ ${args[0]} == +5 ]]
+	[[ ${args[1]} =~ .*/editor.bats ]]
+}


### PR DESCRIPTION
This adds the environment variable `EDITORLINEFLAGREVERSED`.  If it is set to true, the order of line number and file path is reversed:

| `EDITORLINEFLAGREVERSED` | command |
|----|----|
| 0 / unset | `editor /path/to/file +line` |
| 1 | `editor +line /path/to/file` |

To preserve existing behaviour, the implementation retains the original checks as a fallback.

I wonder what you think, looking forward to your feedback.