### PR TITLE
handle *grep errors

### DIFF
--- a/test/errors.bats
+++ b/test/errors.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats -t
+
+load helpers
+
+# Create a write-only file which causes the *grep implementations to fail. In
+# that case, vgrep should still parse the stdout of *grep and return the error
+# reported on stdout along with the exit code.
+
+WONLY_FILE=test/search_files/wonly.txt
+
+function setup() {
+	touch $WONLY_FILE
+	chmod 200 $WONLY_FILE
+}
+
+function teardown() {
+	rm $WONLY_FILE
+}
+
+@test "Search with permission error" {
+	run_vgrep --no-header foo test/search_files
+	[ "$status" -eq 2 ]
+	[[ ${lines[0]} =~ "test/search_files/wonly.txt: Permission denied (os error 13)" ]]
+	[[ ${lines[1]} =~ "bar baz" ]]
+}
+
+@test "Search with permission error (--no-ripgrep)" {
+        # Since the file isn't under version control, git will not try to read it
+	run_vgrep --no-header --no-ripgrep foo test/search_files
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "bar baz" ]]
+}
+
+@test "Search with permission error (--no-git --no-ripgrep)" {
+	run_vgrep --no-header --no-git --no-ripgrep foo test/search_files
+	[ "$status" -eq 2 ]
+	[[ ${lines[0]} =~ "test/search_files/wonly.txt: Permission denied" ]]
+	[[ ${lines[1]} =~ "bar baz" ]]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -15,7 +15,9 @@ function run_vgrep() {
 	fi
 	run $VGREP $args "$@"
 	if [ "$status" -ne 0 ]; then
+		echo "-------------"
 		echo "CLI: $VGREP $args $*"
 		echo "OUT: $output"
+		echo "-------------"
 	fi
 }


### PR DESCRIPTION
Try parsing the stdout of *grep even in case of an error. This allows to return output when hitting, for instance, eperms on certain files.

The stderr of *grep is now logged directly while the exit code is being recorded and used by vgrep on exit.

Fixes: #216