### PR TITLE
test/errors.bats: pass as root

### DIFF
--- a/test/errors.bats
+++ b/test/errors.bats
@@ -9,12 +9,15 @@ load helpers
 WONLY_FILE=test/search_files/wonly.txt
 
 function setup() {
+	if is_root; then
+		skip "Requires running as non-root"
+	fi
 	touch $WONLY_FILE
 	chmod 200 $WONLY_FILE
 }
 
 function teardown() {
-	rm $WONLY_FILE
+	rm -f $WONLY_FILE
 }
 
 @test "Search with permission error" {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -21,3 +21,7 @@ function run_vgrep() {
 		echo "-------------"
 	fi
 }
+
+function is_root() {
+    [ "$(id -u)" -eq 0 ]
+}


### PR DESCRIPTION
The tests need to be skipped when running as root, so let's skip them conditionally.